### PR TITLE
Return 500 on exception

### DIFF
--- a/lib/rack/oauth2/server.rb
+++ b/lib/rack/oauth2/server.rb
@@ -213,9 +213,10 @@ module Rack
             # 5.2.  The WWW-Authenticate Response Header Field
             logger.info "RO2S: HTTP authorization failed #{error.code}" if logger
             return unauthorized(request, error)
-          rescue =>ex
+          rescue => ex
             logger.info "RO2S: HTTP authorization failed #{ex.message}" if logger
-            return unauthorized(request)
+            request.env['rack.exception'] = ex
+            return [ 500, {}, [ex.message || ""] ]
           end
 
           # We expect application to use 403 if request has insufficient scope,


### PR DESCRIPTION
Currently all exceptions are caught and treated as "401 unauthorized", including database exceptions.  However, the semantics of 401 imply that it's the credentials that are invalid and there's no need to retry, when in fact this could be caused by a transient error.  Instead, return 500 on uncaught exception.
